### PR TITLE
DSL for contracts

### DIFF
--- a/lib/obvious/contract.rb
+++ b/lib/obvious/contract.rb
@@ -25,6 +25,34 @@ class Contract
     end
   end
 
+  # Public: Defines a contract for a method
+  #
+  # method - a symbol representing the method name
+  # contract - a hash with the keys :input and :output holding the respective shapes.
+  #
+  # Examples
+  #
+  #   class FooJackContract < Contract
+  #
+  #     contract_for :save, {
+  #       :input  => Foo.shape,
+  #       :output => Foo.shape,
+  #     }
+  #
+  #   end
+  #
+  def self.contract_for method, contract
+    method_alias    = "#{method}_alias".to_sym
+    method_contract = "#{method}_contract".to_sym
+
+    define_method method_contract do |*args|
+      input = args[0]
+      call_method method_alias, input, contract[:input], contract[:output]
+    end
+
+    contracts( *contract_list, method )
+  end
+
   # This method will move methods defined in @contracts into new methods.
   # Each entry in @contracts will cause the method with the same name to
   # become method_name_alias and for the original method to point to


### PR DESCRIPTION
The method for defining contracts seemed a little more complex than it needed to be:

``` ruby
contracts :save

def save_contract input
  input_shape = User.shape
  output_shape = User.shape
  call_method :save_alias, input, input_shape, output_shape
end
```

This requires me to know how the Contract class is renaming methods save_contract and save_alias and will make it hard or impossible for those behind-the-scenes details to change in the future without breaking compatibility. I also have to write the `save_contract` method _and_ list it as a contract at the top of the file. What I've attempted to do is introduce a bit of a DSL for expressing the same logic in a simpler, declarative style. So the above becomes this:

``` ruby
contract_for :save, {                                                                                                                                        
  :input  => User.shape,                                                                                                                                   
  :output => User.shape,                                                                                                                                   
} 
```

I'm open to ideas if you think there's a better way to do this. Let me know what you think.

Trevor

PS. I'll be submitting a pull request to update the obvious_status example to use this new format.
