### PR TITLE
ci: add GitHub Action for tests

### DIFF
--- a/.github/workflows/obvious.yml
+++ b/.github/workflows/obvious.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.1.0
           bundler-cache: true
       - run: |
           bundle exec rspec

--- a/.github/workflows/obvious.yml
+++ b/.github/workflows/obvious.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.1.0
-        bundler-cache: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.0
+          bundler-cache: true
       - run: |
           bundle exec rspec

--- a/.github/workflows/obvious.yml
+++ b/.github/workflows/obvious.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 3.1.0
-          bundler-cache: true
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1.0
+        bundler-cache: true
       - run: |
           bundle exec rspec

--- a/.github/workflows/obvious.yml
+++ b/.github/workflows/obvious.yml
@@ -1,0 +1,15 @@
+name: obvious
+
+on: [push]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+      - run: |
+          bundle exec rspec

--- a/spec/obj_spec.rb
+++ b/spec/obj_spec.rb
@@ -56,7 +56,7 @@ describe Obvious::Obj do
 
       expect {@test.defined_method with_foo: 'hello', also_bar: nil }.to raise_error { |error|
         error.should be_a ArgumentError
-        error.message.should eq 'invalid type for also_bar expected Fixnum'
+        error.message.should eq 'invalid type for also_bar expected Integer'
       } 
     end
   end


### PR DESCRIPTION
This adds a GitHub Action to run unit tests via RSpec.

The test change is because Fixnum and Bignum were unified into Integer with Ruby 2.4.

https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/