### PR TITLE
ci: run unit tests against additional Ruby versions

### DIFF
--- a/.github/workflows/obvious.yml
+++ b/.github/workflows/obvious.yml
@@ -6,7 +6,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1 ]
+        ruby: [ 2.6, 2.7, '3.0', 3.1 ]
     name: Ruby ${{ matrix.ruby }} unit tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/obvious.yml
+++ b/.github/workflows/obvious.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.0
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: |
           bundle exec rspec

--- a/.github/workflows/obvious.yml
+++ b/.github/workflows/obvious.yml
@@ -4,6 +4,10 @@ on: [push]
 
 jobs:
   unit-tests:
+    strategy:
+      matrix:
+        ruby: [ 2.5, 2.6, 2.7, 3.1 ]
+    name: ${{ matrix.ruby }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/obvious.yml
+++ b/.github/workflows/obvious.yml
@@ -6,7 +6,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        ruby: [ 2.6, 2.7, '3.0', 3.1 ]
+        ruby: [ 2.7, '3.0', 3.1 ]
     name: Ruby ${{ matrix.ruby }} unit tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/obvious.yml
+++ b/.github/workflows/obvious.yml
@@ -6,8 +6,8 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, 3.1 ]
-    name: ${{ matrix.ruby }}
+        ruby: [ 2.5, 2.6, 2.7, 3.0, 3.1 ]
+    name: Ruby ${{ matrix.ruby }} unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/obvious.yml
+++ b/.github/workflows/obvious.yml
@@ -6,7 +6,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, 3.0, 3.1 ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1 ]
     name: Ruby ${{ matrix.ruby }} unit tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Now unit tests are run against Ruby 2.6, 2.7, 3.0, and 3.1.

Ruby 2.6 was chosen as the minimum version as it is earliest version that hasn't been EOL'd per [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/).