### PR TITLE
Bumping Obvious version to 0.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    obvious (0.0.10)
+    obvious (0.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -22,6 +22,7 @@ GEM
     rspec-support (3.10.3)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
   x86_64-linux
 

--- a/lib/obvious/version.rb
+++ b/lib/obvious/version.rb
@@ -1,3 +1,3 @@
 module Obvious
-  VERSION = "0.0.10"
+  VERSION = "0.1.0"
 end

--- a/obvious.gemspec
+++ b/obvious.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Brian Knapp"]
   gem.email         = ["brianknapp@gmail.com"]
   gem.description   = "A set of tools to build apps using the Obvious Architecture"
-  gem.summary       = "Isn't it Obvious?"
+  gem.summary       = "Clean Architecture framework"
   gem.homepage      = "http://obvious.retromocha.com/"
 
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
This takes the latest minor changes and bumps the Obvious gem to version `0.1.0`. 