### PR TITLE
fix: Refactors Obvious::Obj to be simpler

### DIFF
--- a/lib/obvious/obj.rb
+++ b/lib/obvious/obj.rb
@@ -5,31 +5,29 @@ module Obvious
         base.extend ClassMethods
       end
     end
-   
+
     module ClassMethods
 
-      def define method, input = {}, &block 
-        define_method(method)  do |method_input = {}| 
+      def define method, input = {}, &block
+        define_method(method) do |method_input = {}|
           block_input = {}
-          method_input.each do |k,v| 
-            if input[k].nil? 
+          method_input.each do |k,v|
+            if input[k].nil?
               raise ArgumentError.new "invalid input field #{k}"
-            end 
+            end
 
-            unless v.is_a? input[k][1]
-              raise ArgumentError.new "invalid type for #{k} expected #{input[k][1]}"
-            end 
-
-            block_input[input[k][0]] = v
+            unless v.is_a? input[k]
+              raise ArgumentError.new "invalid type for #{k} expected #{input[k]}"
+            end
           end
-   
+
           input.each do |k,v|
-            if block_input[v[0]].nil?
+            if method_input[k].nil?
               raise ArgumentError.new "missing input field #{k}"
             end
           end
 
-          self.instance_exec block_input, &block 
+          self.instance_exec method_input, &block
         end
       end
 

--- a/spec/obj_spec.rb
+++ b/spec/obj_spec.rb
@@ -1,18 +1,23 @@
 require_relative '../lib/obvious/obj'
 
 class TestObj
-  include Obvious::Obj 
+  include Obvious::Obj
 
-  def initialize 
+  def initialize
     @local = 'set!'
   end
 
-  define :defined_method, with_foo: [:foo, String], also_bar: [:bar, Integer] do |input|
+  define :defined_method, foo: String, bar: Integer do |input|
     input
   end
 
   define :defined_local do |input|
     @local
+  end
+
+  define :early_return_example do |input|
+    next true
+    false
   end
 
 end
@@ -25,39 +30,44 @@ describe Obvious::Obj do
 
   describe 'self.define' do
     it 'should do the right thing with correct input' do
-      result = @test.defined_method with_foo: 'hello', also_bar: 12
+      result = @test.defined_method foo: 'hello', bar: 12
       expect(result).to eq foo: 'hello', bar: 12
     end
 
     it 'should have access to instance variables' do
       result = @test.defined_local
-      expect(result).to eq 'set!' 
+      expect(result).to eq 'set!'
     end
 
     it 'should raise an error for missing parameters' do
-      expect { @test.defined_method with_foo: 'hello' }.to raise_error { |error| 
+      expect { @test.defined_method foo: 'hello' }.to raise_error { |error|
         expect(error).to be_a ArgumentError
-        expect(error.message).to eq 'missing input field also_bar'
+        expect(error.message).to eq 'missing input field bar'
       }
     end
 
     it 'should raise an error for extra parameters' do
-      expect { @test.defined_method with_foo: 'hello', also_bar: 12, and_extra: 'this is extra!' }.to raise_error { |error|
+      expect { @test.defined_method foo: 'hello', bar: 12, extra: 'this is extra!' }.to raise_error { |error|
         expect(error).to be_a ArgumentError
-        expect(error.message).to eq 'invalid input field and_extra'
+        expect(error.message).to eq 'invalid input field extra'
       }
     end
 
     it 'should raise an error for invalid types' do
-      expect { @test.defined_method with_foo: 1, also_bar: 12 }.to raise_error { |error|
-        expect(error).to be_a ArgumentError 
-        expect(error.message).to eq 'invalid type for with_foo expected String'
+      expect { @test.defined_method foo: 1, bar: 12 }.to raise_error { |error|
+        expect(error).to be_a ArgumentError
+        expect(error.message).to eq 'invalid type for foo expected String'
       }
 
-      expect {@test.defined_method with_foo: 'hello', also_bar: nil }.to raise_error { |error|
+      expect {@test.defined_method foo: 'hello', bar: nil }.to raise_error { |error|
         expect(error).to be_a ArgumentError
-        expect(error.message).to eq 'invalid type for also_bar expected Integer'
-      } 
+        expect(error.message).to eq 'invalid type for bar expected Integer'
+      }
+    end
+
+    it 'should allow for early returns in control flow' do
+      result = @test.early_return_example
+      expect(result).to eq true
     end
   end
 


### PR DESCRIPTION
This changes the syntax for using an `Obvious::Obj` to no longer use keyword args like Obj-C and instead is a simple type check.

Example:

```
class MyObject
  include Obvious::Obj
  
  define :example_method, foo: String, bar: Integer do |input|
    input
  end
end
```

Usage:

```
MyObject.new.example_method(foo: "Hi", bar: 12)
```

I think this is a pretty sane way to add typed boundaries to `Actions` without being too verbose. Also of note, the input on the method is just a hash, so it is easy enough to pass in data dynamically and have it still type checked and feel clean to use.

https://github.com/RetroMocha/obvious/issues/55